### PR TITLE
Increment version number after PR merge.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "60fps-scroll",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/ryanseddon/60fps-scroll",
   "authors": [
     "Ryan Seddon"


### PR DESCRIPTION
If bower has a cached version, then the bug fix from PR #5 will not be effective.
